### PR TITLE
feat: レシピを提案してもらうときに画像も生成して表示する

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -52,7 +52,7 @@ export default function RootLayout({
         <Header />
         <main className="flex-1 relative">
           <div className="absolute inset-0 bg-wallpaper-auth bg-cover bg-center bg-fixed" />
-          <div className="absolute inset-0 flex items-center justify-center overflow-auto">
+          <div className="absolute inset-0 flex items-center justify-center overflow-auto pt-[1000px]">
             {children}
           </div>
         </main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -52,7 +52,7 @@ export default function RootLayout({
         <Header />
         <main className="flex-1 relative">
           <div className="absolute inset-0 bg-wallpaper-auth bg-cover bg-center bg-fixed" />
-          <div className="absolute inset-0 flex items-center justify-center overflow-auto pt-[1000px]">
+          <div className="absolute inset-0 flex items-center justify-center overflow-auto">
             {children}
           </div>
         </main>

--- a/components/features/Chat/Chat.tsx
+++ b/components/features/Chat/Chat.tsx
@@ -93,7 +93,7 @@ const Chat: React.FC = () => {
 
     try {
       const response = await getRecipeDetails(detailsRequestData);
-      setDetails(response.parsedContent);
+      setDetails(response.recipeDetails);
     } catch (error: any) {
       toast({
         title: "レシピの取得に失敗しました",

--- a/components/features/Chat/partials/RecipeDetails.tsx
+++ b/components/features/Chat/partials/RecipeDetails.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { RecipeDetails as RecipeDetailsType } from "@/types/cooking";
+import Image from "next/image";
 
 type Props = {
   details: RecipeDetailsType;
@@ -28,6 +29,13 @@ export const RecipeDetails: React.FC<Props> = (data) => {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
+        <Image
+          src={details.imageUrl}
+          alt={details.recipeName}
+          width={512}
+          height={512}
+          className="w-full h-auto object-cover rounded-xl"
+        />
         <Table>
           <TableHeader>
             <TableRow>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,38 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {};
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const nextConfig = {
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@styles": path.resolve(__dirname, "app"),
+      "@components": path.resolve(__dirname, "components"),
+    };
+    return config;
+  },
+  // 外部からの画像の読み込みを許可する
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "firebasestorage.googleapis.com",
+        port: "",
+        pathname: "/v0/b/**",
+      },
+      {
+        protocol: "https",
+        hostname: "oaidalleapiprodscus.blob.core.windows.net",
+        port: "",
+        pathname: "/private/**",
+      },
+    ],
+  },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+};
 
 export default nextConfig;

--- a/types/cooking.ts
+++ b/types/cooking.ts
@@ -12,4 +12,5 @@ export type RecipeDetails = {
   ingredients: Ingredient[];
   process: string[];
   point: string;
+  imageUrl: string;
 };


### PR DESCRIPTION
## issue
- resolve #39 

## 実装内容
- 料理名をもとに画像を生成してAPIからのレスポンスに含め、クライアント側で表示する

## 実装後

<img width="1687" alt="スクリーンショット 2024-08-15 9 37 25" src="https://github.com/user-attachments/assets/c4cda668-7e60-4636-a997-892dceb9d86f">

